### PR TITLE
Add committer name and date of commit to tooltip.

### DIFF
--- a/src/bin/git-graphviz
+++ b/src/bin/git-graphviz
@@ -96,7 +96,7 @@ digraph git_graph {
 EOF
 
     {
-        git log --pretty="format:%h %s" "$@"
+        git log --pretty="format:%h %s %cn %ci" "$@"
         printf '\n'
     } > "$git_graphviz"/commits.txt
 


### PR DESCRIPTION
I got this working on my linux system here and thought it would be useful to add the name of the person who committed the change and date committed. I didn't even know there was a tooltip feature. Nice!
